### PR TITLE
Fix Version being set globally  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'http://rubygems.org'
 gemspec
 
 gem 'rake'

--- a/ar_merge.gemspec
+++ b/ar_merge.gemspec
@@ -2,10 +2,11 @@
 require File.expand_path('../lib/ar_merge/version', __FILE__)
 
 Gem::Specification.new do |gem|
+  gem.name = "ar_merge"
   gem.summary = "Merge 2 ActiveRecords, preserving associations and attributes"
   gem.authors = ["Michael Grosser"]
   gem.email = "michael@grosser.it"
-  gem.homepage = "http://github.com/grosser/#{name}"
+  gem.homepage = "http://github.com/grosser/ar_merge"
   gem.files = `git ls-files`.split("\n")
   gem.license = "MIT"
   gem.version = ARMerge::VERSION

--- a/ar_merge.gemspec
+++ b/ar_merge.gemspec
@@ -1,13 +1,14 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
-name = "ar_merge"
-require "#{name}/version"
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/ar_merge/version', __FILE__)
 
-Gem::Specification.new name, ARMerge::VERSION do |s|
-  s.summary = "Merge 2 ActiveRecords, preserving associations and attributes"
-  s.authors = ["Michael Grosser"]
-  s.email = "michael@grosser.it"
-  s.homepage = "http://github.com/grosser/#{name}"
-  s.files = `git ls-files`.split("\n")
-  s.license = "MIT"
-  s.add_runtime_dependency "activerecord"
+Gem::Specification.new do |gem|
+  gem.summary = "Merge 2 ActiveRecords, preserving associations and attributes"
+  gem.authors = ["Michael Grosser"]
+  gem.email = "michael@grosser.it"
+  gem.homepage = "http://github.com/grosser/#{name}"
+  gem.files = `git ls-files`.split("\n")
+  gem.license = "MIT"
+  gem.version = ARMerge::VERSION
+
+  gem.add_runtime_dependency "activerecord"
 end

--- a/lib/ar_merge/version.rb
+++ b/lib/ar_merge/version.rb
@@ -1,3 +1,3 @@
 module ARMerge
-  VERSION = Version = '0.2.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
0.2.0 has a bug where `Version` is set globally through the whole rails app.

This was causing my app problems because I have a rails model named `Version` and instead of giving me an AR model it was giving me a string "0.2.0", which is caused by this gem.

I have fixed this by updating the gemspec to be more inline with how must gems lay it out.
